### PR TITLE
Added share allocation widget

### DIFF
--- a/lib/company/asset/ShareAllocationWidget.dart
+++ b/lib/company/asset/ShareAllocationWidget.dart
@@ -1,0 +1,53 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fairsite/providers/firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart';
+
+const totalShares = 60;
+
+class ShareAllocationWidget extends StatefulWidget {
+  @override
+  _ShareAllocationWidgetState createState() => _ShareAllocationWidgetState();
+}
+
+class _ShareAllocationWidgetState extends State<ShareAllocationWidget> {
+  final firestore = FirebaseFirestore.instance;
+  List<Map<String, dynamic>> ownerAndShareCount = [];
+
+  @override
+  void initState() {
+    super.initState();
+    getData();
+  }
+
+  void getData() async {
+    final data = await firestore.collection('company/1111/shares').get();
+    data.docs.forEach((doc) {
+      ownerAndShareCount.add({
+        'name': doc.data()['owner'],
+        'shares': doc.data()['shareCount'],
+      });
+    });
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Column(
+        children: [
+          const Text('Shares'),
+          ...ownerAndShareCount
+              .map((data) => ListTile(
+                    title: Text(data['name']),
+                    subtitle: Text(
+                        '${data['shares'].toString()} (%${(data['shares'] * 100 / totalShares).toStringAsFixed(2)})'),
+                  ))
+              .toList(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/company/company_list_page.dart
+++ b/lib/company/company_list_page.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fairsite/company/asset/ShareAllocationWidget.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -55,6 +56,7 @@ class CompanyListPage extends ConsumerWidget {
                         : CompanyDetails(
                             ref.watch(activeList)!, selectedItem.notifier),
                   ),
+                  Expanded(child: ShareAllocationWidget())
                   // Expanded(
                   //     child: Card(
                   //         child: Column(


### PR DESCRIPTION
I created the widget and displayed it as a column for now. After the admin view is added I can make it so only we can see it. I also added each person shares in the database.

I left the image so you can see how it looks.
![Share allocation widget](https://user-images.githubusercontent.com/113388382/217673685-5c4caf56-0d0a-41a1-89c2-58ae75ec9d69.PNG)
